### PR TITLE
Clear the list of webhooks when the bot reconnects to discord

### DIFF
--- a/webhook-bridge.py
+++ b/webhook-bridge.py
@@ -397,6 +397,7 @@ def main():
             for webhook in channel_webhooks:
                 if webhook.name == "_minecraft":
                     global WEBHOOKS
+                    WEBHOOKS = []
                     WEBHOOKS.append(webhook.url)
                     found = True
                 logging.debug("Found webhook {} in channel {}".format(webhook.name, discord_channel.name))


### PR DESCRIPTION
This prevents duplicate webhooks (and in consequence duplicate messages) from being added to the webhook list when the bot loses connection to discord and reconnects.