### PR TITLE
Use build script instead of mysteriously delete github docker actions

### DIFF
--- a/.github/workflows/masterdockerimage.yml
+++ b/.github/workflows/masterdockerimage.yml
@@ -12,31 +12,13 @@ jobs:
     steps:
     - name: Check out the repo
       uses: actions/checkout@v1
-    - name: Login to Docker Hub
-      uses: actions/docker/login@master
-      env:
-        DOCKER_USERNAME: starcraft66
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
     - name: Run tox
       uses: tox-dev/gh-action-tox@master
+    - name: Build and push the Docker image
+      run: ./build.sh
       env:
-        DOCKER_USERNAME: starcraft66
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
-    - name: Login to the GitHub Package Registry
-      uses: actions/docker/login@master
-      env:
-        DOCKER_REGISTRY_URL: "docker.pkg.github.com"
-        DOCKER_USERNAME: starcraft66
-        DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN_OWNED }}
-    - name: Build the master docker image
-      uses: actions/docker/cli@master
-      with:
-        args: "build -t starcraft66/minecraft-discord-bridge:latest -t docker.pkg.github.com/starcraft66/minecraft-discord-bridge/minecraft-discord-bridge:latest ."
-    - name: Push the master docker image to Docker Hub
-      uses: actions/docker/cli@master
-      with:
-        args: "push starcraft66/minecraft-discord-bridge:latest"
-    - name: Push the master docker image to GitHub Package Registry
-      uses: actions/docker/cli@master
-      with:
-        args: "push docker.pkg.github.com/starcraft66/minecraft-discord-bridge/minecraft-discord-bridge:latest"
+        DOCKER_HUB_USERNAME: starcraft66
+        DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_TOKEN }}
+        DOCKER_GH_REGISTRY_URL: "docker.pkg.github.com"
+        DOCKER_GH_USERNAME: starcraft66
+        DOCKER_GH_PASSWORD: ${{ secrets.GITHUB_TOKEN_OWNED }}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+docker login --username $DOCKER_GH_USERNAME --password $DOCKER_GH_PASSWORD $DOCKER_GH_REGISTRY_URL
+echo "Building docker image."
+docker build --tag starcraft66/minecraft-discord-bridge:latest --tag docker.pkg.github.com/starcraft66/minecraft-discord-bridge/minecraft-discord-bridge:latest .
+echo "Pushing image to docker hub."
+docker push starcraft66/minecraft-discord-bridge:latest
+echo "Pushing image to github packages."
+docker push docker.pkg.github.com/starcraft66/minecraft-discord-bridge/minecraft-discord-bridge:latest
+echo "Done building."


### PR DESCRIPTION
Github deleted the `actions/docker` repository for seemingly no reason without providing a replacement so this is a last-ditch effort to try to continue to use their actions product.

I temporarily set `on: pull_request` to test this change. I will force-push a change to make this workflow only run on master if I can validate that this change works.