### PR TITLE
Reconnect failsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All of the configuration data is stored in a file called `config.json` that must
 |MAIN.DISCORD_APP_TOKEN     |""                         |The discord bot token the birdge will use to log into discord
 |MAIN.LOG_LEVEL             |"INFO"                     |Set the log level, can be `INFO` or `DEBUG`
 |MAIN.MESSAGE_DELAY         |1.5                        |Set the delay between messages sent from discord to minecraft
+|MAIN.FAILSAFE_RETRIES      |3                          |The amount of times to try reconnecting to an online server before giving up and exiting.
 |MAIN.ADMINS                |\[283983554051047425\]     |Array of discord user ids that have administrative access to the bot
 |AUTH_SERVER.BIND.IP        |""                         |The IPv4 address which the authentication server will bind to (set to blank for 0.0.0.0)
 |AUTH_SERVER.PORT           |9822                       |The port which the authentication server will bind to

--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,7 @@
         "DISCORD_APP_TOKEN": "",
         "LOG_LEVEL": "INFO",
         "MESSAGE_DELAY": 1.5,
+        "FAILSAFE_RETRIES": 3,
         "ADMINS": [
             283983554051047425
         ]

--- a/minecraft_discord_bridge/config.py
+++ b/minecraft_discord_bridge/config.py
@@ -36,6 +36,7 @@ class Configuration(object):
                 self.discord_token = self._config["MAIN"]["DISCORD_APP_TOKEN"]
                 self.logging_level = self._config["MAIN"]["LOG_LEVEL"]
                 self.message_delay = self._config["MAIN"]["MESSAGE_DELAY"]
+                self.failsafe_retries = self._config["MAIN"]["FAILSAFE_RETRIES"]
                 self.admin_users = self._config["MAIN"]["ADMINS"]
                 self.auth_ip = self._config["AUTH_SERVER"]["BIND_IP"]
                 self.auth_port = self._config["AUTH_SERVER"]["PORT"]


### PR DESCRIPTION
Adds a config setting `MAIN.FAILSAFE_RETRIES` (defaults to 3) that allows the administrator to specify how many times the bridge should try to connect to a server before giving up and exiting.
A connection is considered successful when the bridge's Minecraft player successfully joins the game and is spawned into the world.

This can be used as a stop-gap solution for #59 and #62. A process supervisor like `systemd` or `docker` should be used to restart the bridge automatically when it exits.