### PR TITLE
Add a command-line argument parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![](https://github.com/starcraft66/minecraft-discord-bridge/workflows/Docker%20Image/badge.svg)
+![](https://img.shields.io/docker/pulls/starcraft66/minecraft-discord-bridge)
 # Minecraft Discord Bridge
 Required Python version: 3.5 or later.
 
@@ -27,8 +28,10 @@ Docker is not required to run this bot but its use is strongly encouraged for ea
         python -m pipenv install
         python -m pipenv run python -m minecraft_discord_bridge
         ```
+    
+    2. You may optionally specify a custom path to the json configuration file using the `--config-file` or `-f` command-line options. E.g. `python -m pipenv run python -m minecraft_discord_bridge -f /path/to/custom/config`.
         
-    2. If you are using docker, just use the included `docker-compose.yml` to get up and running.
+    3. If you are using docker, just use the included `docker-compose.yml` to get up and running.
     
         ```
         docker-compose up -d

--- a/minecraft_discord_bridge/minecraft_discord_bridge.py
+++ b/minecraft_discord_bridge/minecraft_discord_bridge.py
@@ -860,9 +860,9 @@ def handle_sigterm(*args, **kwargs):
 def main():
     signal.signal(signal.SIGTERM, handle_sigterm)
     parser = argparse.ArgumentParser(description="Bridge Minecraft and Discord chat")
-    parser.add_argument("config", metavar="f", help="Path to the configuration file", default="config.json", nargs="?")
+    parser.add_argument("--config-file", "-f", help="Path to the configuration file", default="config.json", nargs="?")
     args = parser.parse_args()
-    bridge = MinecraftDiscordBridge(args.config)
+    bridge = MinecraftDiscordBridge(args.config_file)
     return_code = bridge.run()
     sys.exit(return_code)
     bridge.run()


### PR DESCRIPTION
There should be a command-line argument parser that lets you specify the path to your configuration file.
This is useful for development and for running multiple bridges on the same host.
The README also needs to be updated to document this option.