### PR TITLE
Use java 11 for development mc server

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   minecraft-server:
-    image: itzg/minecraft-server
+    image: itzg/minecraft-server:adopt11
     restart: unless-stopped
     ports:
       - "25565:25565"


### PR DESCRIPTION
The development server used to use an old version of java 8 and paper was throwing deprecation warnings.